### PR TITLE
add s for Apple Symbols fontfamily name. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Symbol Encoding symbols
 (i.e., the output looks yuk, with missing glyphs).
 Just looking for evidence that we are able to select a different font
 at this stage.  Some possibilities are "Helvetica" or 
-"Apple Symbol" on macOS (?) and "Arial" on Windows (?).
+"Apple Symbols" on macOS (?) and "Arial" on Windows (?).
 
 ## Testing the new `cairoSymbolFont()` function
 

--- a/runtests.R
+++ b/runtests.R
@@ -1,0 +1,32 @@
+source("code/common.R")
+cairo_pdf(filename = "plot%03draw.pdf")
+TestChars()
+example(plotmath)
+dev.off()
+
+source("code/common.R")
+cairo_pdf(filename = "plot%03dhelv.pdf", symbolfamily="Helvetica")
+TestChars()
+example(plotmath)
+dev.off()
+
+
+source("code/common.R")
+cairo_pdf(filename = "plot%03dapsym.pdf", symbolfamily="Apple Symbols")
+TestChars()
+example(plotmath)
+dev.off()
+
+
+
+source("code/common.R")
+cairo_pdf(filename = "plot%03dhelvNoPUA.pdf",  symbolfamily=cairoSymbolFont("Helvetica", usePUA=FALSE))
+TestChars()
+example(plotmath)
+dev.off()
+
+source("code/common.R")
+cairo_pdf(filename = "plot%03dapsymNoPUA.pdf",  symbolfamily=cairoSymbolFont("Apple Symbols", usePUA=FALSE))
+TestChars()
+example(plotmath)
+dev.off()


### PR DESCRIPTION
 Add convenience to run tests multiple times with different families and PUA/no PUA and generate differently named pdfs.